### PR TITLE
By default restart vector service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,7 +77,6 @@ class vector (
   String            $vector_executable,
   Vector::Ensure    $service_ensure,
   Vector::Enabled   $service_enabled,
-
   String            $environment_file,
   String            $service_restart    = "yes",
   Hash              $global_options     = {},

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,8 @@
 #   Used in the 'service' resource for vector, default true
 # @param service_enabled
 #   Used in the 'service' resource for vector, default true
+# @param service_restart
+#   Used in the generated systemd unit file, default yes
 # @param environment_file
 #   Location of the environment file for Vector
 # @param global_options
@@ -75,7 +77,9 @@ class vector (
   String            $vector_executable,
   Vector::Ensure    $service_ensure,
   Vector::Enabled   $service_enabled,
+
   String            $environment_file,
+  String            $service_restart    = "yes",
   Hash              $global_options     = {},
   Hash              $environment_vars   = {},
   Hash              $config_files       = {},

--- a/templates/vector.service.epp
+++ b/templates/vector.service.epp
@@ -11,7 +11,7 @@ ExecStartPre=<%= $vector::vector_executable %> validate -C <%= $vector::setup::t
 ExecStart=<%= $vector::vector_executable %> -c <%= $vector::configure::global_opts_file %> -C <%= $vector::setup::topology_files_dir %>
 ExecReload=<%= $vector::vector_executable %> validate -C <%= $vector::setup::topology_files_dir %> <%= $vector::configure::global_opts_file %>
 ExecReload=/bin/kill -HUP $MAINPID
-Restart=no
+Restart=<%= $vector::service_restart %>
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 EnvironmentFile=-<%= $vector::environment_file %>
 


### PR DESCRIPTION
As a log shipper I want to have it restarted every times it fails. This ensures automatic recovery during and prevents uneeded human interaction.

Systemd will automatically limit the restart to avoid restart storms.