### PR TITLE
allow permissions to be configured on config/data directories

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -64,7 +64,9 @@ The following parameters are available in the `vector` class:
 * [`version`](#-vector--version)
 * [`install_vector`](#-vector--install_vector)
 * [`config_dir`](#-vector--config_dir)
+* [`config_dir_mode`](#-vector--config_dir_mode)
 * [`data_dir`](#-vector--data_dir)
+* [`data_dir_mode`](#-vector--data_dir_mode)
 * [`user`](#-vector--user)
 * [`group`](#-vector--group)
 * [`manage_user`](#-vector--manage_user)
@@ -104,11 +106,23 @@ Data type: `String`
 
 Base directory for configuration, default /etc/vector
 
+##### <a name="-vector--config_dir_mode"></a>`config_dir_mode`
+
+Data type: `String`
+
+File mode for the configuration directory, default 0755
+
 ##### <a name="-vector--data_dir"></a>`data_dir`
 
 Data type: `String`
 
 Directory for vector to store buffer and state data
+
+##### <a name="-vector--data_dir_mode"></a>`data_dir_mode`
+
+Data type: `String`
+
+File mode for the data directory, default 0755
 
 ##### <a name="-vector--user"></a>`user`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -3,7 +3,9 @@ vector::version: ~
 vector::service_name: vector
 vector::install_vector: true
 vector::config_dir: '/etc/vector'
+vector::config_dir_mode: '0755'
 vector::data_dir: '/var/lib/vector'
+vector::data_dir_mode: '0755'
 vector::user: 'vector'
 vector::group: 'vector'
 vector::manage_systemd: true
@@ -19,5 +21,5 @@ vector::user_opts:
   comment: 'Vector observability data router'
   groups: ['systemd-journal', 'systemd-journal-remote']
 vector::group_opts: {}
-  
+
 vector::environment_file: '/etc/sysconfig/vector'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 #
 # vector
 #
-# @summary 
+# @summary
 #   Vector module for Puppet
 #
 # Installs, configures, then runs the Vector log and metric tool on RedHat and Debian type systems
@@ -21,8 +21,12 @@
 #   Whether to have this module install Vector. Using this means the version param is ignored
 # @param config_dir
 #   Base directory for configuration, default /etc/vector
+# @param config_dir_mode
+#   File mode for the configuration directory, default 0755
 # @param data_dir
 #   Directory for vector to store buffer and state data
+# @param data_dir_mode
+#   File mode for the data directory, default 0755
 # @param user
 #   What user to run Vector as, default 'vector'
 # @param group
@@ -67,7 +71,9 @@ class vector (
   Optional[String]  $version,
   Boolean           $install_vector,
   String            $config_dir,
+  String            $config_dir_mode,
   String            $data_dir,
+  String            $data_dir_mode,
   String            $user,
   String            $group,
   Boolean           $manage_user,

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -12,23 +12,23 @@ class vector::setup {
   file { $vector::data_dir:
     ensure => directory,
     owner  => $vector::user,
-    mode   => '0755',
+    mode   => $vector::data_dir_mode,
   }
 
   file { $vector::config_dir:
     ensure => directory,
-    mode   => '0755',
+    mode   => $vector::config_dir_mode,
   }
   -> file { $topology_files_dir:
     ensure  => directory,
-    mode    => '0755',
+    mode    => $vector::config_dir_mode,
     recurse => true,
     purge   => true,
     notify  => Class['vector::service'],
   }
   -> file { [$sources_dir, $transforms_dir, $sinks_dir]:
     ensure  => directory,
-    mode    => '0755',
+    mode    => $vector::config_dir_mode,
     recurse => true,
     purge   => true,
     notify  => Class['vector::service'],


### PR DESCRIPTION
This PR adds two new config points, `data_dir_mode` and `config_dir_mode` to manage permissions on the relevant directories. The defaults replicate the old values (0755) so this should be a no-op for current consumers.